### PR TITLE
Add example for https workarounds

### DIFF
--- a/Dockerfile.https
+++ b/Dockerfile.https
@@ -1,0 +1,8 @@
+FROM oracle/graalvm-ce:1.0.0-rc9
+RUN yum  install -y java-1.8.0-openjdk-headless \
+	&& update-alternatives --set java $JAVA_HOME/bin/java \
+        && mv $JAVA_HOME/jre/lib/security/cacerts $JAVA_HOME/jre/lib/security/cacerts.bak \
+	&& ln -s /usr/lib/jvm/jre-1.8.0/lib/security/cacerts $JAVA_HOME/jre/lib/security/cacerts
+
+CMD tail -f /dev/null
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Create API gateways by running update-aws.sh script in the application directori
 
 Run the tests with using test.sh script. 
  
+## GraalVM HTTPS support
+There is example Dockerfile with HTTPS workarounds, you can use it to create Docker image for
+GraalVM compilation with command: 
+````
+docker build -f Dockerfile.https -t graal-build-img .
+````
+and then use script *update-aws-https.sh* to load compiled program to AWS Lambda.
 
 
 

--- a/clojure-graalvm-example/update-aws-https.sh
+++ b/clojure-graalvm-example/update-aws-https.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+echo "Building Clojure uberjar"
+lein uberjar
+
+if [ ! "$(docker ps -a -q -f 'name=graal-builder')" ]; then
+  echo "DB container does not exists, creating it"
+  docker run --name graal-builder -dt graal-build-img:latest
+else
+  echo "Container already running"
+fi
+set -eu
+
+docker cp target/uberjar/server.jar graal-builder:server.jar
+
+docker exec graal-builder native-image -H:+ReportUnsupportedElementsAtRuntime -H:EnableURLProtocols=http,https -J-Xmx3G -J-Xms3G --no-server -jar server.jar --rerun-class-initialization-at-runtime=org.httpkit.client.SslContextFactory --rerun-class-initialization-at-runtime=org.httpkit.client.HttpClient
+
+docker cp graal-builder:server target/server
+docker exec cp $JAVA_HOME/jre/lib/amd64/libsunec.so $PWD
+docker cp graal-builder:libsunec.so target/libsunec.so
+zip -j target/bundle.zip src/bootstrap target/server
+
+TIMESTAMP=$(date +%s)
+echo $TIMESTAMP.zip > latest.tag
+aws s3 cp target/bundle.zip s3://$(aws ssm get-parameter --name=/graalvm-test/s3-artifact-bucket | jq -r '.Parameter.Value')/$TIMESTAMP.zip
+
+aws cloudformation deploy --stack-name=graal-infra --template-file=../lambda.yml --parameter-overrides \
+    CodeTag=$TIMESTAMP.zip \
+    Runtime=provided \
+    FunctionName=graalvm-test \
+    Handler=not.needed \
+    Memory=1000
+
+ENDPOINT=$(aws cloudformation describe-stacks --stack-name=graal-infra| jq -r '.Stacks[0].Outputs[0].OutputValue')
+echo "Test the api at $ENDPOINT"
+echo $ENDPOINT > endpoint.uri


### PR DESCRIPTION
Dockerfile for graal-builder, new update-aws-https.sh with HTTPS workarounds and mention these changes in README.md